### PR TITLE
Handle ingredient groups

### DIFF
--- a/src/Recipe.js
+++ b/src/Recipe.js
@@ -35,8 +35,8 @@ export class Recipe extends Component {
   }
 
   getRecipe (idToken, recipeId) {
-    axios.defaults.headers.common['Authorization'] = 'Bearer ' + this.props.idToken
-    axios.get('http://localhost:3050/api/v1/recipes/' + params.id)
+    axios.defaults.headers.common['Authorization'] = 'Bearer ' + idToken
+    axios.get('http://localhost:3050/api/v1/recipes/' + recipeId)
       .then((response) => { // TODO: deal with error
         let recipe = response.data
         if (recipe && recipe.ingredients) {

--- a/src/Recipe.js
+++ b/src/Recipe.js
@@ -131,6 +131,9 @@ export class EditableRecipe extends Component {
     delete recipeObject.protein
     delete recipeObject.carbs
     delete recipeObject.fat
+    // Recreate ingredients structure in a way the server can understand. Ingredients needs to be a string (currently an array, ingredientList is the value we want)
+    recipeObject.ingredients = recipeObject.ingredientList
+    delete recipeObject.ingredientList
 
     axios.put('http://localhost:3050/api/v1/recipes/' + this.state.recipe._id, recipeObject)
       .then((response) => {

--- a/src/Recipe.test.js
+++ b/src/Recipe.test.js
@@ -260,7 +260,7 @@ describe('Recipe component', () => {
         servings: 4,
         prepTime: '20m',
         cookingTime: '30m',
-        ingredients: '1 g test ingredient\ntest ingredient without quantity or unit',
+        ingredients: '1 g test ingredient\ntest ingredient without quantity or unit\n# test group\n1 cup test ingredient2\n1 g test ingredient3\n# new group\n1 test ingredient without unit',
         instructions: '',
         storage: 'fridge',
         notes: 'new recipe',

--- a/src/Recipe.test.js
+++ b/src/Recipe.test.js
@@ -18,7 +18,13 @@ describe('Recipe', () => {
         author: 'test author',
         image: '',
         source: 'test source',
-        ingredients: [{ quantity: 1, unit: 'g', name: 'test ingredient' }, { name: 'test ingredient without quantity or unit' }],
+        ingredients: [
+          { quantity: 1, unit: 'g', name: 'test ingredient' },
+          { name: 'test ingredient without quantity or unit' },
+          { quantity: 1, unit: 'cup', name: 'test ingredient2', group: 'test group' },
+          { quantity: 1, unit: 'g', name: 'test ingredient3', group: 'test group' },
+          { quantity: 1, name: 'test ingredient without unit', group: 'new group' }
+        ],
         tags: ['test', 'new'],
         instructions: '',
         servings: 4,
@@ -156,8 +162,8 @@ describe('Recipe', () => {
       prepTimeText.simulate('change', { target: { value: 'new preptime', name: 'prepTime' } })
       const cookingTimeText = wrapper.find('#cookingTimeText').at(0)
       cookingTimeText.simulate('change', { target: { value: 'new cooking time', name: 'cookingTime' } })
-      const ingredientsText = wrapper.find('#ingredientsText').at(0)
-      ingredientsText.simulate('change', { target: { value: 'new ingredients', name: 'ingredients' } })
+      const ingredientListText = wrapper.find('#ingredientListText').at(0)
+      ingredientListText.simulate('change', { target: { value: 'new ingredients', name: 'ingredientList' } })
       const instructionsText = wrapper.find('#instructionsText').at(0)
       instructionsText.simulate('change', { target: { value: 'new instructions', name: 'instructions' } })
       const storageText = wrapper.find('#storageText').at(0)
@@ -182,7 +188,7 @@ describe('Recipe', () => {
       tryCheck.simulate('change', { target: { checked: true, name: 'wantToTry', type: 'checkbox' } })
       const doneCheck = wrapper.find('#doneCheck').at(0)
       doneCheck.simulate('change', { target: { checked: true, name: 'done', type: 'checkbox' } })
-      expect(wrapper.state().recipe).toEqual({
+      expect(wrapper.state().recipe).toMatchObject({
         _id: '1234',
         title: 'new title',
         url: 'new url',
@@ -193,7 +199,7 @@ describe('Recipe', () => {
         servings: 'new servings',
         prepTime: 'new preptime',
         cookingTime: 'new cooking time',
-        ingredients: 'new ingredients',
+        ingredientList: 'new ingredients',
         instructions: 'new instructions',
         storage: 'new storage',
         notes: 'new notes',


### PR DESCRIPTION
Be able to display and save recipes with ingredient groupings.
When updating the recipe, display the ingredients in the textarea in this way:
- An ingredients group name will be a line that starts with `#`
- Any ingredient after a group name belongs to a group

When displaying the recipe, display the ingredients:
- An ingredients group name will be in bold
- Any ingredient after a group name belongs to a group

