### PR TITLE
Add home dashboard and modify search component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6710,7 +6710,8 @@
     "gud": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
+      "dev": true
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -9462,6 +9463,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
       "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.0",
         "gud": "^1.0.0",
@@ -9472,6 +9474,7 @@
           "version": "7.9.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
           "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -9479,7 +9482,8 @@
         "regenerator-runtime": {
           "version": "0.13.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
         }
       }
     },
@@ -12303,6 +12307,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
       "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
@@ -12320,6 +12325,7 @@
           "version": "4.10.1",
           "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
           "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.1.2",
             "loose-envify": "^1.2.0",
@@ -12332,7 +12338,69 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "resolve-pathname": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+          "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+          "dev": true
+        },
+        "value-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+          "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+          "dev": true
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "mini-create-react-context": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+          "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "tiny-warning": "^1.0.3"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.11.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+              "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            }
+          }
         },
         "path-to-regexp": {
           "version": "1.8.0",
@@ -12342,30 +12410,23 @@
             "isarray": "0.0.1"
           }
         },
-        "resolve-pathname": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-          "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-        },
-        "value-equal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-          "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+        "react-router": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+          "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "history": "^4.9.0",
+            "hoist-non-react-statics": "^3.1.0",
+            "loose-envify": "^1.3.1",
+            "mini-create-react-context": "^0.4.0",
+            "path-to-regexp": "^1.7.0",
+            "prop-types": "^15.6.2",
+            "react-is": "^16.6.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0"
+          }
         }
-      }
-    },
-    "react-router-dom": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
-      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.1.2",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
       }
     },
     "react-scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "qs": "^6.9.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-router-dom": "^5.1.0",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
     "reactstrap": "^7.1.0"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,6 @@ import { Header } from './Header'
 
 function App () {
   const [idToken, setIdToken] = React.useState(null)
-  const [searchString, setSearchString] = React.useState('')
 
   useEffect(() => {
     /* istanbul ignore next */
@@ -38,9 +37,9 @@ function App () {
   return (
     <div>
       <Router>
-        <Header setSearchString={setSearchString} />
+        <Header />
         <Switch>
-          <Route exact path='/' render={/* istanbul ignore next */ (routeProps) => <Dashboard {...routeProps} idToken={idToken} searchString={searchString} />} />
+          <Route exact path='/' render={/* istanbul ignore next */ (routeProps) => <Dashboard {...routeProps} idToken={idToken} />} />
           <Route path='/recipes/:id' render={/* istanbul ignore next */ (routeProps) => <Recipe {...routeProps} idToken={idToken} />} />
           <Route path='/lists/:id' render={/* istanbul ignore next */ (routeProps) => <List {...routeProps} idToken={idToken} />} />
         </Switch>

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,13 @@
 import React, { useEffect } from 'react'
-import { Navbar, NavItem, Nav, NavbarBrand } from 'reactstrap'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { Recipe } from './Recipe'
-import { Search } from './Search'
 import { List } from './List'
+import { Dashboard } from './Dashboard'
+import { Header } from './Header'
 
 function App () {
   const [idToken, setIdToken] = React.useState(null)
+  const [searchString, setSearchString] = React.useState('')
 
   useEffect(() => {
     /* istanbul ignore next */
@@ -36,17 +37,10 @@ function App () {
 
   return (
     <div>
-      <Navbar color='light' light expand='md'>
-        <NavbarBrand href='/'>sugar-salt-butter</NavbarBrand>
-        <Nav className='ml-auto' navbar>
-          <NavItem>
-            <div id='my-signIn' className='g-signin2' />
-          </NavItem>
-        </Nav>
-      </Navbar>
       <Router>
+        <Header setSearchString={setSearchString} />
         <Switch>
-          <Route exact path='/' render={/* istanbul ignore next */ (routeProps) => <Search {...routeProps} idToken={idToken} />} />
+          <Route exact path='/' render={/* istanbul ignore next */ (routeProps) => <Dashboard {...routeProps} idToken={idToken} searchString={searchString} />} />
           <Route path='/recipes/:id' render={/* istanbul ignore next */ (routeProps) => <Recipe {...routeProps} idToken={idToken} />} />
           <Route path='/lists/:id' render={/* istanbul ignore next */ (routeProps) => <List {...routeProps} idToken={idToken} />} />
         </Switch>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import { mount } from 'enzyme'
 import { MemoryRouter } from 'react-router'
 import { Recipe } from './Recipe'
-import { Search } from './Search'
+import { Dashboard } from './Dashboard'
 import { List } from './List'
 import App from './App'
 
@@ -72,13 +72,13 @@ describe('App component', () => {
     expect(wrapper.find(Recipe)).toHaveLength(0)
   })
 
-  it('renders Search component on / path', () => {
+  it('renders Dashboard component on / path', () => {
     const wrapper = mount(
       <MemoryRouter initialEntries={['/']}>
         <App />
       </MemoryRouter>
     )
-    expect(wrapper.find(Search)).toHaveLength(1)
+    expect(wrapper.find(Dashboard)).toHaveLength(1)
     expect(wrapper.find(List)).toHaveLength(0)
     expect(wrapper.find(Recipe)).toHaveLength(0)
   })

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from 'react'
+import { Container } from 'reactstrap'
+import { RecipeCard } from './RecipeCard'
+import { Search } from './Search'
+import './Styles.css'
+
+const axios = require('axios')
+
+export function Dashboard ({ idToken, searchString }) {
+  const [recentlyAdded, setRecentlyAdded] = useState([])
+  const [wantToTry, setWantToTry] = useState([])
+
+  useEffect(() => {
+    if (!idToken) return
+    axios.defaults.headers.common.Authorization = 'Bearer ' + idToken
+
+    axios.get('http://localhost:3050/api/v1/recipes?limit=8')
+      .then((response) => { // TODO: deal with error
+        setRecentlyAdded(prevState => ([...prevState, ...response.data.recipes]))
+      })
+    axios.get('http://localhost:3050/api/v1/recipes?wantToTry=true&limit=8')
+      .then((response) => { // TODO: deal with error
+        setWantToTry(prevState => ([...prevState, ...response.data.recipes]))
+      })
+  }, [idToken])
+
+  const dashboard = (
+    <Container fluid='xl'>
+      <p>Recently added:</p>
+      <ul className='results'>
+        {recentlyAdded.map((recipe) => <RecipeCard key={recipe._id} data={recipe} />)}
+      </ul>
+      <hr />
+      <p>Want to try:</p>
+      <ul className='results'>
+        {wantToTry.map((recipe) => <RecipeCard key={recipe._id} data={recipe} />)}
+      </ul>
+    </Container>
+  )
+
+  const searchComponent = <Search searchString={searchString} idToken={idToken} />
+
+  return (
+    <>
+      {searchString ? searchComponent : dashboard}
+    </>
+  )
+}

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import qs from 'qs'
 import { Container } from 'reactstrap'
 import { RecipeCard } from './RecipeCard'
 import { Search } from './Search'
@@ -6,9 +7,10 @@ import './Styles.css'
 
 const axios = require('axios')
 
-export function Dashboard ({ idToken, searchString }) {
+export function Dashboard ({ idToken, location }) {
   const [recentlyAdded, setRecentlyAdded] = useState([])
   const [wantToTry, setWantToTry] = useState([])
+  const [searchString, setSearchString] = useState('')
 
   useEffect(() => {
     if (!idToken) return
@@ -23,6 +25,11 @@ export function Dashboard ({ idToken, searchString }) {
         setWantToTry(prevState => ([...prevState, ...response.data.recipes]))
       })
   }, [idToken])
+
+  useEffect(() => {
+    const queryObj = qs.parse(location.search.substring(1, location.search.length))
+    setSearchString(queryObj.searchString)
+  }, [location.search])
 
   const dashboard = (
     <Container fluid='xl'>

--- a/src/Dashboard.test.js
+++ b/src/Dashboard.test.js
@@ -1,11 +1,12 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import axios from 'axios'
 import { Dashboard } from './Dashboard'
 import { act } from 'react-dom/test-utils'
 
 jest.mock('axios')
 const recipesUrl = 'http://localhost:3050/api/v1/recipes'
+const location = { search: '' }
 
 describe('Dashboard component', () => {
   let recipes = {
@@ -55,7 +56,7 @@ describe('Dashboard component', () => {
 
   it('does not get recipes if there is no idToken', () => {
     act(() => {
-      mount(<Dashboard />)
+      mount(<Dashboard location={location} />)
     })
 
     expect(axios.get).toHaveBeenCalledTimes(0)
@@ -64,7 +65,7 @@ describe('Dashboard component', () => {
   it('gets all recipes by userId when receiving an idToken', async () => {
     let wrapper
     await act(async () => {
-      wrapper = mount(<Dashboard idToken='testUser' />)
+      wrapper = mount(<Dashboard idToken='testUser' location={location} />)
     })
     expect(axios.get).toHaveBeenCalledTimes(2)
     expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
@@ -79,7 +80,7 @@ describe('Dashboard component', () => {
   it('gets all recipes by userId when props updated with idToken', async () => {
     let wrapper
     await act(async () => {
-      wrapper = mount(<Dashboard />)
+      wrapper = mount(<Dashboard location={location} />)
     })
 
     expect(axios.get).toHaveBeenCalledTimes(0)
@@ -93,15 +94,14 @@ describe('Dashboard component', () => {
     expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?wantToTry=true&limit=8')
   })
 
-  it('displays search component if searchString is set', async () => {
+  it('displays search component if querystring has search values', async () => {
     let wrapper
+    let location = { search: '?searchString=cake' }
     await act(async () => {
-      wrapper = shallow(<Dashboard idToken='testUser' searchString='cake' />)
+      wrapper = mount(<Dashboard idToken='testUser' location={location} />)
     })
-    expect(axios.get).toHaveBeenCalledTimes(0)
 
     wrapper.update() // Re-render component
     expect(wrapper.find('Search').length).toEqual(1)
-    expect(wrapper.find('RecipeCard').length).toEqual(0)
   })
 })

--- a/src/Dashboard.test.js
+++ b/src/Dashboard.test.js
@@ -5,6 +5,7 @@ import { Dashboard } from './Dashboard'
 import { act } from 'react-dom/test-utils'
 
 jest.mock('axios')
+const recipesUrl = 'http://localhost:3050/api/v1/recipes'
 
 describe('Dashboard component', () => {
   let recipes = {
@@ -67,8 +68,8 @@ describe('Dashboard component', () => {
     })
     expect(axios.get).toHaveBeenCalledTimes(2)
     expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes?limit=8')
-    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes?wantToTry=true&limit=8')
+    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?limit=8')
+    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?wantToTry=true&limit=8')
 
     wrapper.update() // Re-render component
     expect(wrapper.find('RecipeCard').length).toEqual(3)
@@ -88,8 +89,8 @@ describe('Dashboard component', () => {
     })
     expect(axios.get).toHaveBeenCalledTimes(2)
     expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes?limit=8')
-    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes?wantToTry=true&limit=8')
+    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?limit=8')
+    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?wantToTry=true&limit=8')
   })
 
   it('displays search component if searchString is set', async () => {

--- a/src/Dashboard.test.js
+++ b/src/Dashboard.test.js
@@ -1,0 +1,106 @@
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import axios from 'axios'
+import { Dashboard } from './Dashboard'
+import { act } from 'react-dom/test-utils'
+
+jest.mock('axios')
+
+describe('Dashboard component', () => {
+  let recipes = {
+    data: {
+      count: 2,
+      recipes: [{
+        _id: 'recipe1',
+        title: 'first recipe',
+        image: '/img.png',
+        servings: 1,
+        wantToTry: true
+      },
+      {
+        _id: 'recipe2',
+        title: 'second recipe',
+        image: '/recipe.jpeg'
+      }]
+    }
+  }
+
+  let wantToTryRecipes = {
+    data: {
+      count: 1,
+      recipes: [{
+        _id: 'recipe1',
+        title: 'first recipe',
+        image: '/img.png',
+        servings: 1,
+        wantToTry: true
+      }]
+    }
+  }
+
+  beforeEach(() => {
+    axios.get.mockImplementation((url) => {
+      if (url.indexOf('wantToTry') > -1) {
+        return Promise.resolve(wantToTryRecipes)
+      } else {
+        return Promise.resolve(recipes)
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does not get recipes if there is no idToken', () => {
+    act(() => {
+      mount(<Dashboard />)
+    })
+
+    expect(axios.get).toHaveBeenCalledTimes(0)
+  })
+
+  it('gets all recipes by userId when receiving an idToken', async () => {
+    let wrapper
+    await act(async () => {
+      wrapper = mount(<Dashboard idToken='testUser' />)
+    })
+    expect(axios.get).toHaveBeenCalledTimes(2)
+    expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
+    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes?limit=8')
+    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes?wantToTry=true&limit=8')
+
+    wrapper.update() // Re-render component
+    expect(wrapper.find('RecipeCard').length).toEqual(3)
+    expect(wrapper.find('Search').length).toEqual(0)
+  })
+
+  it('gets all recipes by userId when props updated with idToken', async () => {
+    let wrapper
+    await act(async () => {
+      wrapper = mount(<Dashboard />)
+    })
+
+    expect(axios.get).toHaveBeenCalledTimes(0)
+
+    await act(async () => {
+      wrapper.setProps({ idToken: 'testUser' })
+    })
+    expect(axios.get).toHaveBeenCalledTimes(2)
+    expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
+    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes?limit=8')
+    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes?wantToTry=true&limit=8')
+  })
+
+  it('displays search component if searchString is set', async () => {
+    let wrapper
+    await act(async () => {
+      wrapper = shallow(<Dashboard idToken='testUser' searchString='cake' />)
+    })
+    expect(axios.get).toHaveBeenCalledTimes(0)
+
+    wrapper.update() // Re-render component
+    expect(wrapper.find('Search').length).toEqual(1)
+    expect(wrapper.find('RecipeCard').length).toEqual(0)
+  })
+})

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,21 +1,13 @@
 import React from 'react'
 import { Navbar, NavItem, Nav, NavbarBrand } from 'reactstrap'
-import { useHistory } from 'react-router-dom'
 import { SearchForm } from './SearchForm'
 import './Styles.css'
 
-export function Header ({ setSearchString }) {
-  const history = useHistory()
-
-  const onSearch = (searchText) => {
-    setSearchString(searchText)
-    history.push('/')
-  }
-
+export function Header () {
   return (
     <Navbar color='light' light expand='md'>
       <NavbarBrand href='/'>sugar-salt-butter</NavbarBrand>
-      <SearchForm search={onSearch} />
+      <SearchForm />
       <Nav className='ml-auto' navbar>
         <NavItem>
           <div id='my-signIn' className='g-signin2' />

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Navbar, NavItem, Nav, NavbarBrand } from 'reactstrap'
+import { useHistory } from 'react-router-dom'
+import { SearchForm } from './SearchForm'
+import './Styles.css'
+
+export function Header ({ setSearchString }) {
+  const history = useHistory()
+
+  const onSearch = (searchText) => {
+    setSearchString(searchText)
+    history.push('/')
+  }
+
+  return (
+    <Navbar color='light' light expand='md'>
+      <NavbarBrand href='/'>sugar-salt-butter</NavbarBrand>
+      <SearchForm search={onSearch} />
+      <Nav className='ml-auto' navbar>
+        <NavItem>
+          <div id='my-signIn' className='g-signin2' />
+        </NavItem>
+      </Nav>
+    </Navbar>
+  )
+}

--- a/src/Header.test.js
+++ b/src/Header.test.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { Router } from 'react-router-dom'
+import { Header } from './Header'
+
+const historyMock = { push: jest.fn(), location: {}, listen: jest.fn() }
+
+describe('Header component', () => {
+  it('submitting search form changes router history', () => {
+    const setSearchStringMock = jest.fn()
+
+    const wrapper = mount(
+      <Router history={historyMock}>
+        <Header setSearchString={setSearchStringMock} />
+      </Router>
+    )
+
+    const headerWrapper = wrapper.find('Header').at(0)
+    const searchForm = headerWrapper.find('SearchForm').at(0)
+    searchForm.props().search('cake') // call search function
+
+    expect(setSearchStringMock).toHaveBeenCalledTimes(1)
+    expect(setSearchStringMock).toHaveBeenCalledWith('cake')
+    expect(historyMock.push).toHaveBeenCalledTimes(1)
+    expect(historyMock.push).toHaveBeenCalledWith('/')
+  })
+})

--- a/src/Header.test.js
+++ b/src/Header.test.js
@@ -1,27 +1,11 @@
 import React from 'react'
-import { mount } from 'enzyme'
-import { Router } from 'react-router-dom'
+import ReactDOM from 'react-dom'
 import { Header } from './Header'
 
-const historyMock = { push: jest.fn(), location: {}, listen: jest.fn() }
-
 describe('Header component', () => {
-  it('submitting search form changes router history', () => {
-    const setSearchStringMock = jest.fn()
-
-    const wrapper = mount(
-      <Router history={historyMock}>
-        <Header setSearchString={setSearchStringMock} />
-      </Router>
-    )
-
-    const headerWrapper = wrapper.find('Header').at(0)
-    const searchForm = headerWrapper.find('SearchForm').at(0)
-    searchForm.props().search('cake') // call search function
-
-    expect(setSearchStringMock).toHaveBeenCalledTimes(1)
-    expect(setSearchStringMock).toHaveBeenCalledWith('cake')
-    expect(historyMock.push).toHaveBeenCalledTimes(1)
-    expect(historyMock.push).toHaveBeenCalledWith('/')
+  it('renders without crashing', () => {
+    const div = document.createElement('div')
+    ReactDOM.render(<Header />, div)
+    ReactDOM.unmountComponentAtNode(div)
   })
 })

--- a/src/RecipeCard.js
+++ b/src/RecipeCard.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import './Styles.css'
+
+export function RecipeCard (props) {
+  const linkToRecipe = 'recipes/' + props.data._id
+  return (
+    <li className='recipeBox'>
+      <a href={linkToRecipe} className='recipeCard'>
+        <img src={props.data.image} className='recipeCardImage' alt={props.data.title} /><br />
+        <p className='recipeCardTitle'>{props.data.title}</p>
+      </a>
+    </li>
+  )
+}

--- a/src/Search.js
+++ b/src/Search.js
@@ -28,7 +28,7 @@ export function Search ({ idToken, searchString }) {
     if (!idToken) return // Do not make a search if we do not have an idToken!
 
     setIsLoading(true)
-    axios.get('http://localhost:3050/api/v1/recipes/search?searchString=' + searchString + '&skip=' + skip)
+    axios.get('http://localhost:3050/api/v1/recipes?searchString=' + searchString + '&skip=' + skip)
       .then((response) => { // TODO: deal with error
         setSearchResults(prevState => ([...prevState, ...response.data.recipes]))
         setSearchCount(response.data.count)

--- a/src/Search.js
+++ b/src/Search.js
@@ -1,13 +1,11 @@
-import React, { useState, useEffect, useRef } from 'react'
-import { Button, Form, Input } from 'reactstrap'
+import React, { useState, useEffect } from 'react'
 import debounce from 'lodash.debounce'
+import { RecipeCard } from './RecipeCard'
 import './Styles.css'
 
 const axios = require('axios')
 
-export function Search ({ idToken }) {
-  const refInput = useRef()
-  const [searchString, setSearchString] = useState('')
+export function Search ({ idToken, searchString }) {
   const [searchResults, setSearchResults] = useState([])
   const [searchCount, setSearchCount] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
@@ -38,16 +36,10 @@ export function Search ({ idToken }) {
       })
   }, [searchString, skip, idToken])
 
-  const handleSubmit = (event) => {
-    event.preventDefault()
-
-    const searchText = refInput.current.value
-    if (searchText !== searchString) {
-      setSearchResults([])
-      setSkip(0)
-      setSearchString(searchText)
-    }
-  }
+  useEffect(() => {
+    setSearchResults([])
+    setSkip(0)
+  }, [searchString])
 
   const handleScroll = (event) => {
     debounce((event) => {
@@ -61,10 +53,6 @@ export function Search ({ idToken }) {
 
   return (
     <div>
-      <Form inline onSubmit={handleSubmit}>
-        <Input type='text' innerRef={refInput} name='search' id='searchText' />
-        <Button>Search</Button>
-      </Form>
       {searchResults && searchCount
         ? <div><span>{searchCount} results</span>
           <ul className='results'>
@@ -75,17 +63,5 @@ export function Search ({ idToken }) {
         </div>
         : null}
     </div>
-  )
-}
-
-function RecipeCard (props) {
-  const linkToRecipe = 'recipes/' + props.data._id
-  return (
-    <li className='recipeBox'>
-      <a href={linkToRecipe} className='recipeCard'>
-        <img src={props.data.image} className='recipeCardImage' alt={props.data.title} /><br />
-        <p className='recipeCardTitle'>{props.data.title}</p>
-      </a>
-    </li>
   )
 }

--- a/src/Search.test.js
+++ b/src/Search.test.js
@@ -2,11 +2,8 @@ import React from 'react'
 import { mount } from 'enzyme'
 import axios from 'axios'
 import { Search } from './Search'
-// import debounce from 'lodash/debounce'
 import { act } from 'react-dom/test-utils'
 
-// Tell jest to mock this import
-// jest.mock('lodash/debounce')
 jest.mock('axios')
 jest.useFakeTimers()
 
@@ -33,14 +30,11 @@ describe('Search component', () => {
   describe('handles a search and sends search to server', () => {
     it('and displays results when there are some', async () => {
       axios.get.mockResolvedValue(recipeResults)
-      const wrapper = mount(<Search idToken='testUser' />)
-
-      const form = wrapper.find('form')
-      const searchText = wrapper.find('#searchText').at(0)
-      searchText.getDOMNode().value = 'sugar flour'
+      let wrapper
       await act(async () => {
-        form.simulate('submit')
+        wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
       })
+
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
@@ -52,14 +46,11 @@ describe('Search component', () => {
 
     it('and displays no results when there are none', async () => {
       axios.get.mockResolvedValue({ data: { count: 0, recipes: [] } })
-      const wrapper = mount(<Search idToken='testUser' />)
-
-      const form = wrapper.find('form')
-      const searchText = wrapper.find('#searchText').at(0)
-      searchText.getDOMNode().value = 'sugar flour'
+      let wrapper
       await act(async () => {
-        form.simulate('submit')
+        wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
       })
+
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
@@ -70,14 +61,11 @@ describe('Search component', () => {
     })
 
     it('does not make a request to the server if there is no idToken', async () => {
-      const wrapper = mount(<Search />)
-
-      const form = wrapper.find('form')
-      const searchText = wrapper.find('#searchText').at(0)
-      searchText.getDOMNode().value = 'test'
+      let wrapper
       await act(async () => {
-        form.simulate('submit')
+        wrapper = mount(<Search searchString='sugar flour' />)
       })
+
       expect(axios.get).toHaveBeenCalledTimes(0)
 
       wrapper.update() // Re-render component
@@ -85,14 +73,11 @@ describe('Search component', () => {
     })
 
     it('does not make a request to the server if there is no searchString', async () => {
-      const wrapper = mount(<Search idToken='testUser' />)
-
-      const form = wrapper.find('form')
-      const searchText = wrapper.find('#searchText').at(0)
-      searchText.getDOMNode().value = ''
+      let wrapper
       await act(async () => {
-        form.simulate('submit')
+        wrapper = mount(<Search idToken='testUser' />)
       })
+
       expect(axios.get).toHaveBeenCalledTimes(0)
 
       wrapper.update() // Re-render component
@@ -101,14 +86,11 @@ describe('Search component', () => {
 
     it('makes a clean search after a search', async () => {
       axios.get.mockResolvedValue(recipeResults)
-      const wrapper = mount(<Search idToken='testUser' />)
-
-      const form = wrapper.find('form')
-      const searchText = wrapper.find('#searchText').at(0)
-      searchText.getDOMNode().value = 'sugar flour'
+      let wrapper
       await act(async () => {
-        form.simulate('submit')
+        wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
       })
+
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
@@ -129,9 +111,8 @@ describe('Search component', () => {
         }
       })
 
-      searchText.getDOMNode().value = 'butter'
       await act(async () => {
-        form.simulate('submit')
+        wrapper.setProps({ searchString: 'butter' })
       })
 
       await axios
@@ -144,14 +125,11 @@ describe('Search component', () => {
 
     it('does not make a request to the server if the searchString has not changed', async () => {
       axios.get.mockResolvedValue(recipeResults)
-      const wrapper = mount(<Search idToken='testUser' />)
-
-      const form = wrapper.find('form')
-      const searchText = wrapper.find('#searchText').at(0)
-      searchText.getDOMNode().value = 'sugar flour'
+      let wrapper
       await act(async () => {
-        form.simulate('submit')
+        wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
       })
+
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
@@ -172,9 +150,8 @@ describe('Search component', () => {
         }
       })
 
-      searchText.getDOMNode().value = 'sugar flour'
       await act(async () => {
-        form.simulate('submit')
+        wrapper.setProps({ searchString: 'sugar flour' })
       })
 
       expect(axios.get).toHaveBeenCalledTimes(1)
@@ -200,13 +177,9 @@ describe('Search component', () => {
       }
       it('handles a scroll', async () => {
         axios.get.mockResolvedValue(recipeResults)
-        const wrapper = mount(<Search idToken='testUser' />)
-
-        const form = wrapper.find('form')
-        const searchText = wrapper.find('#searchText').at(0)
-        searchText.getDOMNode().value = 'sugar flour'
+        let wrapper
         await act(async () => {
-          form.simulate('submit')
+          wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
         })
 
         await axios

--- a/src/Search.test.js
+++ b/src/Search.test.js
@@ -7,6 +7,8 @@ import { act } from 'react-dom/test-utils'
 jest.mock('axios')
 jest.useFakeTimers()
 
+const searchUrl = 'http://localhost:3050/api/v1/recipes'
+
 const recipeResults = {
   data: {
     recipes: [{
@@ -38,7 +40,7 @@ describe('Search component', () => {
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes/search?searchString=sugar flour&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(2)
@@ -54,7 +56,7 @@ describe('Search component', () => {
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes/search?searchString=sugar flour&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(0)
@@ -94,7 +96,7 @@ describe('Search component', () => {
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes/search?searchString=sugar flour&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(2)
@@ -117,7 +119,7 @@ describe('Search component', () => {
 
       await axios
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes/search?searchString=butter&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=butter&skip=0')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(1)
@@ -133,7 +135,7 @@ describe('Search component', () => {
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes/search?searchString=sugar flour&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(2)
@@ -185,7 +187,7 @@ describe('Search component', () => {
         await axios
         expect(axios.get).toHaveBeenCalledTimes(1)
         expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-        expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes/search?searchString=sugar flour&skip=0')
+        expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
 
         wrapper.update() // Re-render component
         expect(wrapper.find('RecipeCard').length).toEqual(2)
@@ -206,7 +208,7 @@ describe('Search component', () => {
           jest.runAllTimers()
         })
         await axios
-        expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes/search?searchString=sugar flour&skip=2')
+        expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=2')
         wrapper.update() // Re-render component
         expect(wrapper.find('RecipeCard').length).toEqual(4)
       })

--- a/src/SearchForm.js
+++ b/src/SearchForm.js
@@ -1,20 +1,27 @@
-import React, { useRef } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Button, Form, Input } from 'reactstrap'
+import { useHistory } from 'react-router-dom'
+import qs from 'qs'
 import './Styles.css'
 
-export function SearchForm ({ search }) {
-  const refInput = useRef()
+export function SearchForm () {
+  const [searchString, setSearchString] = useState()
+
+  const history = useHistory()
 
   const handleSubmit = (event) => {
     event.preventDefault()
-
-    const searchText = refInput.current.value
-    search(searchText)
+    history.push('?searchString=' + searchString)
   }
+
+  useEffect(() => {
+    const queryObj = qs.parse(window.location.search.substring(1, window.location.search.length))
+    setSearchString(queryObj.searchString)
+  }, [])
 
   return (
     <Form inline onSubmit={handleSubmit}>
-      <Input type='text' innerRef={refInput} name='search' id='searchText' />
+      <Input type='text' value={searchString} onChange={(event) => setSearchString(event.target.value)} name='search' id='searchText' />
       <Button>Search</Button>
     </Form>
   )

--- a/src/SearchForm.js
+++ b/src/SearchForm.js
@@ -1,0 +1,21 @@
+import React, { useRef } from 'react'
+import { Button, Form, Input } from 'reactstrap'
+import './Styles.css'
+
+export function SearchForm ({ search }) {
+  const refInput = useRef()
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+
+    const searchText = refInput.current.value
+    search(searchText)
+  }
+
+  return (
+    <Form inline onSubmit={handleSubmit}>
+      <Input type='text' innerRef={refInput} name='search' id='searchText' />
+      <Button>Search</Button>
+    </Form>
+  )
+}

--- a/src/SearchForm.test.js
+++ b/src/SearchForm.test.js
@@ -1,19 +1,24 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import { Router } from 'react-router-dom'
 import { SearchForm } from './SearchForm'
+
+const historyMock = { push: jest.fn(), location: {}, listen: jest.fn() }
 
 describe('SearchForm component', () => {
   it('submitting form calls search function', () => {
-    const setSearchStringMock = jest.fn()
-
-    const wrapper = mount(<SearchForm search={setSearchStringMock} />)
+    const wrapper = mount(
+      <Router history={historyMock}>
+        <SearchForm />
+      </Router>
+    )
 
     const form = wrapper.find('Form').at(0)
     const searchText = wrapper.find('#searchText').at(0)
-    searchText.getDOMNode().value = 'sugar flour'
+    searchText.simulate('change', { target: { value: 'sugar flour', name: 'search' } })
     form.simulate('submit')
 
-    expect(setSearchStringMock).toHaveBeenCalledTimes(1)
-    expect(setSearchStringMock).toHaveBeenCalledWith('sugar flour')
+    expect(historyMock.push).toHaveBeenCalledTimes(1)
+    expect(historyMock.push).toHaveBeenCalledWith('?searchString=sugar flour')
   })
 })

--- a/src/SearchForm.test.js
+++ b/src/SearchForm.test.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { SearchForm } from './SearchForm'
+
+describe('SearchForm component', () => {
+  it('submitting form calls search function', () => {
+    const setSearchStringMock = jest.fn()
+
+    const wrapper = mount(<SearchForm search={setSearchStringMock} />)
+
+    const form = wrapper.find('Form').at(0)
+    const searchText = wrapper.find('#searchText').at(0)
+    searchText.getDOMNode().value = 'sugar flour'
+    form.simulate('submit')
+
+    expect(setSearchStringMock).toHaveBeenCalledTimes(1)
+    expect(setSearchStringMock).toHaveBeenCalledWith('sugar flour')
+  })
+})


### PR DESCRIPTION
- Add Dashboard component to become home page: for now shows: recently added recipes and recipes with wantToTry=true
- Modify Search component:
  - Separate Search form from Search results component and place form in the new Header component
  - Search is now driven via the query string parameters (allows going back in Browser's navigation history)
  - Use new search API endpoint
- Unit tests for all the above