### PR TITLE
Add tags menu

### DIFF
--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import qs from 'qs'
-import { Container } from 'reactstrap'
+import { Container, Row, Col } from 'reactstrap'
 import { RecipeCard } from './RecipeCard'
 import { Search } from './Search'
+import { TagsMenu } from './TagsMenu'
 import './Styles.css'
 
 const axios = require('axios')
@@ -10,17 +11,17 @@ const axios = require('axios')
 export function Dashboard ({ idToken, location }) {
   const [recentlyAdded, setRecentlyAdded] = useState([])
   const [wantToTry, setWantToTry] = useState([])
-  const [searchString, setSearchString] = useState('')
+  const [searchParams, setSearchParams] = useState({})
 
   useEffect(() => {
     if (!idToken) return
     axios.defaults.headers.common.Authorization = 'Bearer ' + idToken
 
-    axios.get('http://localhost:3050/api/v1/recipes?limit=8')
+    axios.get('http://localhost:3050/api/v1/recipes?limit=7')
       .then((response) => { // TODO: deal with error
         setRecentlyAdded(prevState => ([...prevState, ...response.data.recipes]))
       })
-    axios.get('http://localhost:3050/api/v1/recipes?wantToTry=true&limit=8')
+    axios.get('http://localhost:3050/api/v1/recipes?wantToTry=true&limit=7')
       .then((response) => { // TODO: deal with error
         setWantToTry(prevState => ([...prevState, ...response.data.recipes]))
       })
@@ -28,28 +29,34 @@ export function Dashboard ({ idToken, location }) {
 
   useEffect(() => {
     const queryObj = qs.parse(location.search.substring(1, location.search.length))
-    setSearchString(queryObj.searchString)
+    setSearchParams(queryObj)
   }, [location.search])
 
   const dashboard = (
-    <Container fluid='xl'>
-      <p>Recently added:</p>
+    <Container fluid='xl' className='resultsContainer'>
+      <span>Recently added:</span>
       <ul className='results'>
         {recentlyAdded.map((recipe) => <RecipeCard key={recipe._id} data={recipe} />)}
       </ul>
-      <hr />
-      <p>Want to try:</p>
+      <span>Want to try:</span>
       <ul className='results'>
         {wantToTry.map((recipe) => <RecipeCard key={recipe._id} data={recipe} />)}
       </ul>
     </Container>
   )
 
-  const searchComponent = <Search searchString={searchString} idToken={idToken} />
+  const searchComponent = <Search searchParams={searchParams} idToken={idToken} />
 
   return (
-    <>
-      {searchString ? searchComponent : dashboard}
-    </>
+    <Container fluid>
+      <Row>
+        <Col sm='1' md={{ size: 1 }} className='tagsMenu'>
+          <TagsMenu idToken={idToken} />
+        </Col>
+        <Col sm='11' md={{ size: 11 }}>
+          {Object.keys(searchParams).length > 0 ? searchComponent : dashboard}
+        </Col>
+      </Row>
+    </Container>
   )
 }

--- a/src/Dashboard.test.js
+++ b/src/Dashboard.test.js
@@ -44,6 +44,8 @@ describe('Dashboard component', () => {
     axios.get.mockImplementation((url) => {
       if (url.indexOf('wantToTry') > -1) {
         return Promise.resolve(wantToTryRecipes)
+      } else if (url.indexOf('tags') > -1) {
+        return Promise.resolve({ data: [] })
       } else {
         return Promise.resolve(recipes)
       }
@@ -67,10 +69,9 @@ describe('Dashboard component', () => {
     await act(async () => {
       wrapper = mount(<Dashboard idToken='testUser' location={location} />)
     })
-    expect(axios.get).toHaveBeenCalledTimes(2)
     expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?limit=8')
-    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?wantToTry=true&limit=8')
+    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?limit=7')
+    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?wantToTry=true&limit=7')
 
     wrapper.update() // Re-render component
     expect(wrapper.find('RecipeCard').length).toEqual(3)
@@ -88,10 +89,9 @@ describe('Dashboard component', () => {
     await act(async () => {
       wrapper.setProps({ idToken: 'testUser' })
     })
-    expect(axios.get).toHaveBeenCalledTimes(2)
     expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?limit=8')
-    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?wantToTry=true&limit=8')
+    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?limit=7')
+    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?wantToTry=true&limit=7')
   })
 
   it('displays search component if querystring has search values', async () => {

--- a/src/Search.js
+++ b/src/Search.js
@@ -5,7 +5,7 @@ import './Styles.css'
 
 const axios = require('axios')
 
-export function Search ({ idToken, searchString }) {
+export function Search ({ idToken, searchParams }) {
   const [searchResults, setSearchResults] = useState([])
   const [searchCount, setSearchCount] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
@@ -24,22 +24,25 @@ export function Search ({ idToken, searchString }) {
   })
 
   useEffect(() => {
-    if (!searchString) return
+    if (!searchParams) return
     if (!idToken) return // Do not make a search if we do not have an idToken!
-
+    let searchHref = 'skip=' + skip
+    for (const param of Object.entries(searchParams)) {
+      searchHref += '&' + param[0] + '=' + param[1]
+    }
     setIsLoading(true)
-    axios.get('http://localhost:3050/api/v1/recipes?searchString=' + searchString + '&skip=' + skip)
+    axios.get('http://localhost:3050/api/v1/recipes?' + searchHref)
       .then((response) => { // TODO: deal with error
         setSearchResults(prevState => ([...prevState, ...response.data.recipes]))
         setSearchCount(response.data.count)
         setIsLoading(false)
       })
-  }, [searchString, skip, idToken])
+  }, [searchParams, skip, idToken])
 
   useEffect(() => {
     setSearchResults([])
     setSkip(0)
-  }, [searchString])
+  }, [searchParams])
 
   const handleScroll = (event) => {
     debounce((event) => {
@@ -54,7 +57,7 @@ export function Search ({ idToken, searchString }) {
   return (
     <div>
       {searchResults && searchCount
-        ? <div><span>{searchCount} results</span>
+        ? <div className='resultsContainer'><span>{searchCount} results</span>
           <ul className='results'>
             {searchResults.map((recipe) =>
               <RecipeCard key={recipe._id} data={recipe} />

--- a/src/Search.test.js
+++ b/src/Search.test.js
@@ -8,7 +8,7 @@ jest.mock('axios')
 jest.useFakeTimers()
 
 const searchUrl = 'http://localhost:3050/api/v1/recipes'
-
+const searchParams = { searchString: 'sugar flour' }
 const recipeResults = {
   data: {
     recipes: [{
@@ -34,13 +34,13 @@ describe('Search component', () => {
       axios.get.mockResolvedValue(recipeResults)
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
+        wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
       })
 
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=0&searchString=sugar flour')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(2)
@@ -50,13 +50,13 @@ describe('Search component', () => {
       axios.get.mockResolvedValue({ data: { count: 0, recipes: [] } })
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
+        wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
       })
 
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=0&searchString=sugar flour')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(0)
@@ -65,7 +65,7 @@ describe('Search component', () => {
     it('does not make a request to the server if there is no idToken', async () => {
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search searchString='sugar flour' />)
+        wrapper = mount(<Search searchParams={searchParams} />)
       })
 
       expect(axios.get).toHaveBeenCalledTimes(0)
@@ -90,13 +90,13 @@ describe('Search component', () => {
       axios.get.mockResolvedValue(recipeResults)
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
+        wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
       })
 
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=0&searchString=sugar flour')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(2)
@@ -114,12 +114,12 @@ describe('Search component', () => {
       })
 
       await act(async () => {
-        wrapper.setProps({ searchString: 'butter' })
+        wrapper.setProps({ searchParams: { searchString: 'butter' } })
       })
 
       await axios
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=butter&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=0&searchString=butter')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(1)
@@ -129,13 +129,13 @@ describe('Search component', () => {
       axios.get.mockResolvedValue(recipeResults)
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
+        wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
       })
 
       await axios
       expect(axios.get).toHaveBeenCalledTimes(1)
       expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
+      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=0&searchString=sugar flour')
 
       wrapper.update() // Re-render component
       expect(wrapper.find('RecipeCard').length).toEqual(2)
@@ -181,13 +181,13 @@ describe('Search component', () => {
         axios.get.mockResolvedValue(recipeResults)
         let wrapper
         await act(async () => {
-          wrapper = mount(<Search idToken='testUser' searchString='sugar flour' />)
+          wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
         })
 
         await axios
         expect(axios.get).toHaveBeenCalledTimes(1)
         expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-        expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=0')
+        expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=0&searchString=sugar flour')
 
         wrapper.update() // Re-render component
         expect(wrapper.find('RecipeCard').length).toEqual(2)
@@ -208,7 +208,7 @@ describe('Search component', () => {
           jest.runAllTimers()
         })
         await axios
-        expect(axios.get).toHaveBeenCalledWith(searchUrl + '?searchString=sugar flour&skip=2')
+        expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=2&searchString=sugar flour')
         wrapper.update() // Re-render component
         expect(wrapper.find('RecipeCard').length).toEqual(4)
       })

--- a/src/SearchForm.js
+++ b/src/SearchForm.js
@@ -16,7 +16,7 @@ export function SearchForm () {
 
   useEffect(() => {
     const queryObj = qs.parse(window.location.search.substring(1, window.location.search.length))
-    setSearchString(queryObj.searchString)
+    setSearchString(queryObj.searchString || '')
   }, [])
 
   return (

--- a/src/Styles.css
+++ b/src/Styles.css
@@ -1,6 +1,11 @@
+.resultsContainer {
+    padding: 10px 10px 10px 50px;
+}
+
 .results {
     width:100%;
-    display:block
+    display:block;
+    padding:0px;
 }
 
 .recipeBox {
@@ -150,4 +155,27 @@
     float: right  !important;
     font-weight: 700  !important;
     color: #6c757d  !important;
+}
+
+.tagsMenu {
+    border-right:1px solid #E1E3DF;
+}
+
+.tagsMenuList {
+    height: 100%;
+    list-style-type:none;
+    margin: 10px;
+    padding: 0px;
+    overflow: auto;
+}
+
+.tagsMenuList li {
+    width: 100%;
+    height: auto;
+    word-wrap: break-word;
+}
+
+.tagLink, .tagLink:focus, .tagLink:hover, .tagLink:active {
+    color:#fff;
+    text-decoration: none;
 }

--- a/src/TagsMenu.js
+++ b/src/TagsMenu.js
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import './Styles.css'
+const axios = require('axios')
+
+export function TagsMenu ({ idToken }) {
+  const [tags, setTags] = useState([])
+
+  useEffect(() => {
+    if (!idToken) return
+    axios.defaults.headers.common.Authorization = 'Bearer ' + idToken
+
+    axios.get('http://localhost:3050/api/v1/tags')
+      .then((response) => { // TODO: deal with error
+        setTags(response.data)
+      })
+  }, [idToken])
+
+  const listTags = tags.map((tag) => {
+    const tagHref = '/?tags=' + tag._id
+    return <li key={tag._id}><Link to={tagHref}><strong>{tag._id}</strong> ({tag.count})</Link></li>
+  })
+
+  return (
+    <ul className='tagsMenuList'>
+      {listTags}
+    </ul>
+  )
+}

--- a/src/TagsMenu.test.js
+++ b/src/TagsMenu.test.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { TagsMenu } from './TagsMenu'
+import axios from 'axios'
+import { act } from 'react-dom/test-utils'
+import { Router } from 'react-router-dom'
+
+jest.mock('axios')
+const historyMock = { push: jest.fn(), location: {}, listen: jest.fn(), createHref: jest.fn() }
+
+describe('TagsMenu component', () => {
+  const tags = {
+    data: [
+      { _id: 'meat', count: 20 },
+      { _id: 'vegetarian', count: 1 }
+    ]
+  }
+
+  beforeEach(() => {
+    axios.get.mockResolvedValue(tags)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does not get tags if there is no idToken', () => {
+    act(() => {
+      mount(<TagsMenu />)
+    })
+
+    expect(axios.get).toHaveBeenCalledTimes(0)
+  })
+
+  it('gets tags and displays them if there is idToken', async () => {
+    let wrapper
+    await act(async () => {
+      wrapper = mount(
+        <Router history={historyMock}>
+          <TagsMenu idToken='testUser' />
+        </Router>
+      )
+    })
+    expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
+    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/tags')
+
+    wrapper.update() // Re-render component
+    expect(wrapper.find('li').length).toEqual(2) // 2 tags
+    const firstLink = wrapper.find('Link').at(0)
+    expect(firstLink.props().to).toEqual('/?tags=meat') // First tag Link directs to correct tag
+    expect(firstLink.text()).toEqual('meat (20)')
+    const secondLink = wrapper.find('Link').at(1)
+    expect(secondLink.props().to).toEqual('/?tags=vegetarian')
+    expect(secondLink.text()).toEqual('vegetarian (1)')
+  })
+
+  it('displays no tags if none are returned', async () => {
+    axios.get.mockResolvedValue({ data: [] })
+    let wrapper
+    await act(async () => {
+      wrapper = mount(
+        <Router history={historyMock}>
+          <TagsMenu idToken='testUser' />
+        </Router>
+      )
+    })
+    expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
+    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/tags')
+
+    wrapper.update() // Re-render component
+    expect(wrapper.find('li').length).toEqual(0)
+  })
+})


### PR DESCRIPTION
- new TagsMenu component: 
    - Show list of all tags used across recipes (and count of recipes for each)
    - Each tag is a link that shows recipes with that tag (use the search functionality with tag)
- Adapt Search component to deal with search by tag in query string parameters
- Add TagsMenu component to Dashboard component as a side menu (only appears in Dashboard/Search pages)
- Unit tests
- Temporary styling