### PR TITLE
use React Context for user idToken

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { Recipe } from './Recipe'
 import { List } from './List'
 import { Dashboard } from './Dashboard'
 import { Header } from './Header'
+import { UserContext } from './UserContext'
 
 function App () {
   const [idToken, setIdToken] = React.useState(null)
@@ -39,9 +40,11 @@ function App () {
       <Router>
         <Header />
         <Switch>
-          <Route exact path='/' render={/* istanbul ignore next */ (routeProps) => <Dashboard {...routeProps} idToken={idToken} />} />
-          <Route path='/recipes/:id' render={/* istanbul ignore next */ (routeProps) => <Recipe {...routeProps} idToken={idToken} />} />
-          <Route path='/lists/:id' render={/* istanbul ignore next */ (routeProps) => <List {...routeProps} idToken={idToken} />} />
+          <UserContext.Provider value={idToken}>
+            <Route exact path='/' render={/* istanbul ignore next */ (routeProps) => <Dashboard {...routeProps} />} />
+            <Route path='/recipes/:id' render={/* istanbul ignore next */ (routeProps) => <Recipe {...routeProps} />} />
+            <Route path='/lists/:id' render={/* istanbul ignore next */ (routeProps) => <List {...routeProps} />} />
+          </UserContext.Provider>
         </Switch>
       </Router>
     </div>

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -1,17 +1,20 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import qs from 'qs'
 import { Container, Row, Col } from 'reactstrap'
 import { RecipeCard } from './RecipeCard'
 import { Search } from './Search'
 import { TagsMenu } from './TagsMenu'
 import './Styles.css'
+import { UserContext } from './UserContext'
 
 const axios = require('axios')
 
-export function Dashboard ({ idToken, location }) {
+export function Dashboard ({ location }) {
   const [recentlyAdded, setRecentlyAdded] = useState([])
   const [wantToTry, setWantToTry] = useState([])
   const [searchParams, setSearchParams] = useState({})
+
+  const idToken = useContext(UserContext)
 
   useEffect(() => {
     if (!idToken) return
@@ -45,13 +48,13 @@ export function Dashboard ({ idToken, location }) {
     </Container>
   )
 
-  const searchComponent = <Search searchParams={searchParams} idToken={idToken} />
+  const searchComponent = <Search searchParams={searchParams} />
 
   return (
     <Container fluid>
       <Row>
         <Col sm='1' md={{ size: 1 }} className='tagsMenu'>
-          <TagsMenu idToken={idToken} />
+          <TagsMenu />
         </Col>
         <Col sm='11' md={{ size: 11 }}>
           {Object.keys(searchParams).length > 0 ? searchComponent : dashboard}

--- a/src/Dashboard.test.js
+++ b/src/Dashboard.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme'
 import axios from 'axios'
 import { Dashboard } from './Dashboard'
 import { act } from 'react-dom/test-utils'
+import { UserContext } from './UserContext'
 
 jest.mock('axios')
 const recipesUrl = 'http://localhost:3050/api/v1/recipes'
@@ -58,7 +59,7 @@ describe('Dashboard component', () => {
 
   it('does not get recipes if there is no idToken', () => {
     act(() => {
-      mount(<Dashboard location={location} />)
+      mount(<UserContext.Provider value=''><Dashboard location={location} /></UserContext.Provider>)
     })
 
     expect(axios.get).toHaveBeenCalledTimes(0)
@@ -67,7 +68,7 @@ describe('Dashboard component', () => {
   it('gets all recipes by userId when receiving an idToken', async () => {
     let wrapper
     await act(async () => {
-      wrapper = mount(<Dashboard idToken='testUser' location={location} />)
+      wrapper = mount(<UserContext.Provider value='testUser'><Dashboard location={location} /></UserContext.Provider>)
     })
     expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
     expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?limit=7')
@@ -78,27 +79,11 @@ describe('Dashboard component', () => {
     expect(wrapper.find('Search').length).toEqual(0)
   })
 
-  it('gets all recipes by userId when props updated with idToken', async () => {
-    let wrapper
-    await act(async () => {
-      wrapper = mount(<Dashboard location={location} />)
-    })
-
-    expect(axios.get).toHaveBeenCalledTimes(0)
-
-    await act(async () => {
-      wrapper.setProps({ idToken: 'testUser' })
-    })
-    expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?limit=7')
-    expect(axios.get).toHaveBeenCalledWith(recipesUrl + '?wantToTry=true&limit=7')
-  })
-
   it('displays search component if querystring has search values', async () => {
     let wrapper
     let location = { search: '?searchString=cake' }
     await act(async () => {
-      wrapper = mount(<Dashboard idToken='testUser' location={location} />)
+      wrapper = mount(<UserContext.Provider value='testUser'><Dashboard location={location} /></UserContext.Provider>)
     })
 
     wrapper.update() // Re-render component

--- a/src/EditableRecipe.js
+++ b/src/EditableRecipe.js
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { Button, Form, FormGroup, Label, Input, Row, Col } from 'reactstrap'
 import './Styles.css'
 import { StarRating } from './StarRating'
+import { UserContext } from './UserContext'
 
 const axios = require('axios')
 
@@ -36,6 +37,8 @@ const defaultEditableRecipe = {
 export function EditableRecipe (props) {
   const [recipe, setRecipe] = useState(defaultEditableRecipe)
   const [updatedRecipe, setUpdatedRecipe] = useState(false)
+
+  const idToken = useContext(UserContext)
 
   useEffect(() => {
     const recipe = { ...props.initialRecipe }
@@ -80,7 +83,7 @@ export function EditableRecipe (props) {
     recipeObject.ingredients = recipeObject.ingredientList
     delete recipeObject.ingredientList
 
-    axios.defaults.headers.common.Authorization = 'Bearer ' + props.idToken
+    axios.defaults.headers.common.Authorization = 'Bearer ' + idToken
     axios.put('http://localhost:3050/api/v1/recipes/' + recipe._id, recipeObject)
       .then((response) => {
         setUpdatedRecipe(true)

--- a/src/EditableRecipe.test.js
+++ b/src/EditableRecipe.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme'
 import axios from 'axios'
 import { EditableRecipe } from './EditableRecipe'
 import { act } from 'react-dom/test-utils'
+import { UserContext } from './UserContext'
 
 jest.mock('axios')
 
@@ -74,7 +75,7 @@ describe('EditableRecipe component', () => {
 
   describe('when recipe is editable', () => {
     it('renders form when server returns a recipe', () => {
-      const wrapper = mount(<EditableRecipe initialRecipe={recipeData} idToken='testUser' />)
+      const wrapper = mount(<UserContext.Provider value='testUser'><EditableRecipe initialRecipe={recipeData} /></UserContext.Provider>)
 
       const titleText = wrapper.find('#titleText').at(0)
       expect(titleText.props().value).toEqual(recipeData.title)
@@ -123,7 +124,7 @@ describe('EditableRecipe component', () => {
     })
 
     it('renders editable recipe with basic data', () => {
-      const wrapper = mount(<EditableRecipe initialRecipe={basicRecipeData} idToken='testUser' />)
+      const wrapper = mount(<UserContext.Provider value='testUser'><EditableRecipe initialRecipe={basicRecipeData} /></UserContext.Provider>)
       const titleText = wrapper.find('#titleText').at(0)
       expect(titleText.props().value).toEqual(recipeData.title)
       const ingredientListText = wrapper.find('#ingredientListText').at(0)
@@ -139,7 +140,7 @@ describe('EditableRecipe component', () => {
     })
 
     it('handles a form submit and updates recipe in server', async () => {
-      const wrapper = mount(<EditableRecipe initialRecipe={recipeData} idToken='testUser' />)
+      const wrapper = mount(<UserContext.Provider value='testUser'><EditableRecipe initialRecipe={recipeData} /></UserContext.Provider>)
 
       const titleText = wrapper.find('#titleText').at(0)
       titleText.simulate('change', { target: { value: 'new title', name: 'title' } })
@@ -227,7 +228,7 @@ describe('EditableRecipe component', () => {
     })
 
     it('handles changing the rating', async () => {
-      const wrapper = mount(<EditableRecipe initialRecipe={recipeData} idToken='testUser' />)
+      const wrapper = mount(<UserContext.Provider value='testUser'><EditableRecipe initialRecipe={recipeData} /></UserContext.Provider>)
       const starsWrapper = wrapper.find('StarRating').at(0)
 
       const starButton = starsWrapper.find('.starButton').at(0)

--- a/src/List.js
+++ b/src/List.js
@@ -1,21 +1,21 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { Container, Row, Col, Button } from 'reactstrap'
 import './Styles.css'
 import iconServings from './icons/icons8-restaurant-24.png'
+import { UserContext } from './UserContext'
 
 const axios = require('axios')
 
 export function List (props) {
   const [list, setList] = useState({})
   const [selectedRecipe, setSelectedRecipe] = useState('')
+  const idToken = useContext(UserContext)
 
   useEffect(() => {
+    if (!idToken) return
     const { params } = props.match
-
-    if (props.idToken) {
-      getList(props.idToken, params.id)
-    }
-  }, [props])
+    getList(idToken, params.id)
+  }, [idToken])
 
   const getList = (idToken, listId) => {
     axios.defaults.headers.common.Authorization = 'Bearer ' + idToken

--- a/src/List.test.js
+++ b/src/List.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme'
 import axios from 'axios'
 import { List } from './List'
 import { act } from 'react-dom/test-utils'
+import { UserContext } from './UserContext'
 
 jest.mock('axios')
 
@@ -54,7 +55,7 @@ describe('List component', () => {
   it('does not get list if there is no idToken', () => {
     const match = { params: { id: 'testId' } }
     act(() => {
-      mount(<List match={match} />)
+      mount(<UserContext.Provider value=''><List match={match} /></UserContext.Provider>)
     })
 
     expect(axios.get).toHaveBeenCalledTimes(0)
@@ -64,7 +65,7 @@ describe('List component', () => {
     const match = { params: { id: 'testId' } }
     let wrapper
     await act(async () => {
-      wrapper = mount(<List match={match} idToken='testUser' />)
+      wrapper = mount(<UserContext.Provider value='testUser'><List match={match} /></UserContext.Provider>)
     })
 
     await axios
@@ -83,29 +84,12 @@ describe('List component', () => {
     expect(wrapper.find('.listRecipe li').length).toEqual(2) // 2 recipes
   })
 
-  it('gets list by Id on props updated with idToken', async () => {
-    const match = { params: { id: 'testId' } }
-    let wrapper
-    await act(async () => {
-      wrapper = mount(<List match={match} />)
-    })
-
-    expect(axios.get).toHaveBeenCalledTimes(0)
-
-    await act(async () => {
-      wrapper.setProps({ idToken: 'testUser' })
-    })
-    expect(axios.get).toHaveBeenCalledTimes(1)
-    expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-    expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/lists/testId')
-  })
-
   it('renders nothing if list does not exist', async () => {
     axios.get.mockResolvedValue({ data: null })
     const match = { params: { id: 'testId' } }
     let wrapper
     await act(async () => {
-      wrapper = mount(<List match={match} idToken='testUser' />)
+      wrapper = mount(<UserContext.Provider value='testUser'><List match={match} /></UserContext.Provider>)
     })
     expect(axios.get).toHaveBeenCalledTimes(1)
     expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
@@ -123,7 +107,7 @@ describe('List component', () => {
     const match = { params: { id: 'testId' } }
     let wrapper
     await act(async () => {
-      wrapper = mount(<List match={match} idToken='testUser' />)
+      wrapper = mount(<UserContext.Provider value='testUser'><List match={match} /></UserContext.Provider>)
     })
 
     await axios
@@ -142,7 +126,7 @@ describe('List component', () => {
     const match = { params: { id: 'testId' } }
     let wrapper
     await act(async () => {
-      wrapper = mount(<List match={match} idToken='testUser' />)
+      wrapper = mount(<UserContext.Provider value='testUser'><List match={match} /></UserContext.Provider>)
     })
 
     await axios

--- a/src/ReadonlyRecipe.js
+++ b/src/ReadonlyRecipe.js
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { Button, Input, Badge, InputGroup, InputGroupAddon, InputGroupText, Alert } from 'reactstrap'
 import './Styles.css'
 import iconServings from './icons/icons8-restaurant-24.png'
 import { StarRating } from './StarRating'
 import { Link } from 'react-router-dom'
+import { UserContext } from './UserContext'
 
 const axios = require('axios')
 
@@ -17,10 +18,12 @@ export function ReadonlyRecipe (props) {
 
   const addedToListAlertOnDismiss = () => setAddedToListAlertVisible(false)
 
+  const idToken = useContext(UserContext)
+
   useEffect(() => {
-    axios.defaults.headers.common.Authorization = 'Bearer ' + props.idToken
+    axios.defaults.headers.common.Authorization = 'Bearer ' + idToken
     getLists()
-  }, [props.idToken])
+  }, [idToken])
 
   const recipe = props.recipe
   let listTags

--- a/src/ReadonlyRecipe.test.js
+++ b/src/ReadonlyRecipe.test.js
@@ -4,6 +4,7 @@ import axios from 'axios'
 import { ReadonlyRecipe } from './ReadonlyRecipe'
 import { act } from 'react-dom/test-utils'
 import { Router } from 'react-router-dom'
+import { UserContext } from './UserContext'
 
 jest.mock('axios')
 const historyMock = { push: jest.fn(), location: {}, listen: jest.fn(), createHref: jest.fn() }
@@ -101,7 +102,7 @@ describe('ReadonlyRecipe component', () => {
       axios.get.mockResolvedValue(listsData)
       let wrapper
       await act(async () => {
-        wrapper = mount(<Router history={historyMock}><ReadonlyRecipe recipe={basicRecipeData} idToken='testUser' /></Router>)
+        wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><ReadonlyRecipe recipe={basicRecipeData} /></UserContext.Provider></Router>)
       })
 
       await axios
@@ -126,7 +127,7 @@ describe('ReadonlyRecipe component', () => {
       axios.get.mockResolvedValue({ data: [] })
       let wrapper
       await act(async () => {
-        wrapper = mount(<Router history={historyMock}><ReadonlyRecipe recipe={basicRecipeData} idToken='testUser' /></Router>)
+        wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><ReadonlyRecipe recipe={basicRecipeData} /></UserContext.Provider></Router>)
       })
 
       await axios
@@ -149,7 +150,7 @@ describe('ReadonlyRecipe component', () => {
 
         let wrapper
         await act(async () => {
-          wrapper = mount(<Router history={historyMock}><ReadonlyRecipe recipe={recipeData} idToken='testUser' /></Router>)
+          wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><ReadonlyRecipe recipe={recipeData} /></UserContext.Provider></Router>)
         })
 
         await axios
@@ -188,7 +189,7 @@ describe('ReadonlyRecipe component', () => {
 
         let wrapper
         await act(async () => {
-          wrapper = mount(<Router history={historyMock}><ReadonlyRecipe recipe={recipeData} idToken='testUser' /></Router>)
+          wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><ReadonlyRecipe recipe={recipeData} /></UserContext.Provider></Router>)
         })
 
         await axios

--- a/src/Recipe.js
+++ b/src/Recipe.js
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { Container, Row, Col } from 'reactstrap'
 import qs from 'qs'
 import './Styles.css'
 import { ReadonlyRecipe } from './ReadonlyRecipe'
 import { EditableRecipe } from './EditableRecipe'
+import { UserContext } from './UserContext'
 
 const axios = require('axios')
 
@@ -11,7 +12,11 @@ export function Recipe (props) {
   const [edit, setEdit] = useState(false)
   const [recipe, setRecipe] = useState({})
 
+  const idToken = useContext(UserContext)
+
   useEffect(() => {
+    if (!idToken) return
+
     const { params } = props.match
 
     const { search } = props.location
@@ -20,10 +25,8 @@ export function Recipe (props) {
       setEdit(queryObj.edit)
     }
 
-    if (props.idToken) {
-      getRecipe(props.idToken, params.id)
-    }
-  }, [props])
+    getRecipe(idToken, params.id)
+  }, [props, idToken])
 
   const getRecipe = (idToken, recipeId) => {
     axios.defaults.headers.common.Authorization = 'Bearer ' + idToken
@@ -74,8 +77,8 @@ export function Recipe (props) {
       <Row>
         <Col sm='12' md={{ size: 10, offset: 1 }}>
           {edit === 'true'
-            ? <EditableRecipe initialRecipe={recipe} idToken={props.idToken} />
-            : <ReadonlyRecipe recipe={recipe} idToken={props.idToken} />}
+            ? <EditableRecipe initialRecipe={recipe} />
+            : <ReadonlyRecipe recipe={recipe} />}
         </Col>
       </Row>
     </Container>

--- a/src/Recipe.test.js
+++ b/src/Recipe.test.js
@@ -4,6 +4,7 @@ import axios from 'axios'
 import { Recipe } from './Recipe'
 import { act } from 'react-dom/test-utils'
 import { Router } from 'react-router-dom'
+import { UserContext } from './UserContext'
 
 jest.mock('axios')
 const historyMock = { push: jest.fn(), location: {}, listen: jest.fn(), createHref: jest.fn() }
@@ -148,7 +149,7 @@ describe('Recipe component', () => {
     const match = { params: { id: 'testId' } }
     const location = { search: '' }
     act(() => {
-      mount(<Router history={historyMock}><Recipe location={location} match={match} /></Router>)
+      mount(<Router history={historyMock}><UserContext.Provider value=''><Recipe location={location} match={match} /></UserContext.Provider></Router>)
     })
 
     expect(axios.get).toHaveBeenCalledTimes(0)
@@ -158,7 +159,7 @@ describe('Recipe component', () => {
     const match = { params: { id: 'testId' } }
     const location = { search: '' }
     await act(async () => {
-      mount(<Router history={historyMock}><Recipe location={location} match={match} idToken='testUser' /></Router>)
+      mount(<Router history={historyMock}><UserContext.Provider value='testUser'><Recipe location={location} match={match} /></UserContext.Provider></Router>)
     })
     expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
     expect(axios.get).toHaveBeenCalledWith('http://localhost:3050/api/v1/recipes/testId')
@@ -169,7 +170,7 @@ describe('Recipe component', () => {
       const match = { params: { id: 'testId' } }
       let wrapper
       await act(async () => {
-        wrapper = mount(<Router history={historyMock}><Recipe location={location} match={match} idToken='testUser' /></Router>)
+        wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><Recipe location={location} match={match} /></UserContext.Provider></Router>)
       })
 
       await axios
@@ -185,7 +186,7 @@ describe('Recipe component', () => {
       const location = { search: '?edit=false' }
       let wrapper
       await act(async () => {
-        wrapper = mount(<Router history={historyMock}><Recipe location={location} match={match} idToken='testUser' /></Router>)
+        wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><Recipe location={location} match={match} /></UserContext.Provider></Router>)
       })
 
       await axios
@@ -211,7 +212,7 @@ describe('Recipe component', () => {
       const location = { search: '?edit=false' }
       let wrapper
       await act(async () => {
-        wrapper = mount(<Router history={historyMock}><Recipe location={location} match={match} idToken='testUser' /></Router>)
+        wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><Recipe location={location} match={match} /></UserContext.Provider></Router>)
       })
 
       await axios
@@ -232,7 +233,7 @@ describe('Recipe component', () => {
       const location = { search: '?edit=true' }
       let wrapper
       await act(async () => {
-        wrapper = mount(<Router history={historyMock}><Recipe location={location} match={match} idToken='testUser' /></Router>)
+        wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><Recipe location={location} match={match} /></UserContext.Provider></Router>)
       })
 
       await axios
@@ -253,7 +254,7 @@ describe('Recipe component', () => {
       const location = { search: '?edit=true' }
       let wrapper
       await act(async () => {
-        wrapper = mount(<Router history={historyMock}><Recipe location={location} match={match} idToken='testUser' /></Router>)
+        wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><Recipe location={location} match={match} /></UserContext.Provider></Router>)
       })
 
       await axios
@@ -270,7 +271,7 @@ describe('Recipe component', () => {
       const location = { search: '?edit=true' }
       let wrapper
       await act(async () => {
-        wrapper = mount(<Router history={historyMock}><Recipe location={location} match={match} idToken='testUser' /></Router>)
+        wrapper = mount(<Router history={historyMock}><UserContext.Provider value='testUser'><Recipe location={location} match={match} /></UserContext.Provider></Router>)
       })
 
       await axios

--- a/src/Search.js
+++ b/src/Search.js
@@ -1,15 +1,17 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import debounce from 'lodash.debounce'
 import { RecipeCard } from './RecipeCard'
 import './Styles.css'
+import { UserContext } from './UserContext'
 
 const axios = require('axios')
 
-export function Search ({ idToken, searchParams }) {
+export function Search ({ searchParams }) {
   const [searchResults, setSearchResults] = useState([])
   const [searchCount, setSearchCount] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
   const [skip, setSkip] = useState(0)
+  const idToken = useContext(UserContext)
 
   useEffect(() => {
     if (!idToken) return

--- a/src/Search.test.js
+++ b/src/Search.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme'
 import axios from 'axios'
 import { Search } from './Search'
 import { act } from 'react-dom/test-utils'
+import { UserContext } from './UserContext'
 
 jest.mock('axios')
 jest.useFakeTimers()
@@ -34,7 +35,7 @@ describe('Search component', () => {
       axios.get.mockResolvedValue(recipeResults)
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
+        wrapper = mount(<UserContext.Provider value='testUser'><Search searchParams={searchParams} /></UserContext.Provider>)
       })
 
       await axios
@@ -50,7 +51,7 @@ describe('Search component', () => {
       axios.get.mockResolvedValue({ data: { count: 0, recipes: [] } })
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
+        wrapper = mount(<UserContext.Provider value='testUser'><Search searchParams={searchParams} /></UserContext.Provider>)
       })
 
       await axios
@@ -65,7 +66,7 @@ describe('Search component', () => {
     it('does not make a request to the server if there is no idToken', async () => {
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search searchParams={searchParams} />)
+        wrapper = mount(<UserContext.Provider value=''><Search searchParams={searchParams} /></UserContext.Provider>)
       })
 
       expect(axios.get).toHaveBeenCalledTimes(0)
@@ -77,7 +78,7 @@ describe('Search component', () => {
     it('does not make a request to the server if there is no searchString', async () => {
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search idToken='testUser' />)
+        wrapper = mount(<UserContext.Provider value='testUser'><Search /></UserContext.Provider>)
       })
 
       expect(axios.get).toHaveBeenCalledTimes(0)
@@ -86,50 +87,11 @@ describe('Search component', () => {
       expect(wrapper.find('RecipeCard').length).toEqual(0)
     })
 
-    it('makes a clean search after a search', async () => {
-      axios.get.mockResolvedValue(recipeResults)
-      let wrapper
-      await act(async () => {
-        wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
-      })
-
-      await axios
-      expect(axios.get).toHaveBeenCalledTimes(1)
-      expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=0&searchString=sugar flour')
-
-      wrapper.update() // Re-render component
-      expect(wrapper.find('RecipeCard').length).toEqual(2)
-
-      // Do a new search
-      axios.get.mockResolvedValue({
-        data: {
-          recipes: [{
-            _id: 'recipe5',
-            title: 'test recipe 5',
-            image: 'fakeRecipe5Image.png'
-          }],
-          count: 1
-        }
-      })
-
-      await act(async () => {
-        wrapper.setProps({ searchParams: { searchString: 'butter' } })
-      })
-
-      await axios
-      expect(axios.defaults.headers.common.Authorization).toEqual('Bearer testUser')
-      expect(axios.get).toHaveBeenCalledWith(searchUrl + '?skip=0&searchString=butter')
-
-      wrapper.update() // Re-render component
-      expect(wrapper.find('RecipeCard').length).toEqual(1)
-    })
-
     it('does not make a request to the server if the searchString has not changed', async () => {
       axios.get.mockResolvedValue(recipeResults)
       let wrapper
       await act(async () => {
-        wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
+        wrapper = mount(<UserContext.Provider value='testUser'><Search searchParams={searchParams} /></UserContext.Provider>)
       })
 
       await axios
@@ -181,7 +143,7 @@ describe('Search component', () => {
         axios.get.mockResolvedValue(recipeResults)
         let wrapper
         await act(async () => {
-          wrapper = mount(<Search idToken='testUser' searchParams={searchParams} />)
+          wrapper = mount(<UserContext.Provider value='testUser'><Search searchParams={searchParams} /></UserContext.Provider>)
         })
 
         await axios

--- a/src/TagsMenu.js
+++ b/src/TagsMenu.js
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { Link } from 'react-router-dom'
 import './Styles.css'
+import { UserContext } from './UserContext'
+
 const axios = require('axios')
 
-export function TagsMenu ({ idToken }) {
+export function TagsMenu (props) {
   const [tags, setTags] = useState([])
+  const idToken = useContext(UserContext)
 
   useEffect(() => {
     if (!idToken) return

--- a/src/TagsMenu.test.js
+++ b/src/TagsMenu.test.js
@@ -4,6 +4,7 @@ import { TagsMenu } from './TagsMenu'
 import axios from 'axios'
 import { act } from 'react-dom/test-utils'
 import { Router } from 'react-router-dom'
+import { UserContext } from './UserContext'
 
 jest.mock('axios')
 const historyMock = { push: jest.fn(), location: {}, listen: jest.fn(), createHref: jest.fn() }
@@ -26,7 +27,7 @@ describe('TagsMenu component', () => {
 
   it('does not get tags if there is no idToken', () => {
     act(() => {
-      mount(<TagsMenu />)
+      mount(<UserContext.Provider value=''><TagsMenu /></UserContext.Provider>)
     })
 
     expect(axios.get).toHaveBeenCalledTimes(0)
@@ -37,7 +38,7 @@ describe('TagsMenu component', () => {
     await act(async () => {
       wrapper = mount(
         <Router history={historyMock}>
-          <TagsMenu idToken='testUser' />
+          <UserContext.Provider value='testUser'><TagsMenu /></UserContext.Provider>
         </Router>
       )
     })
@@ -60,7 +61,7 @@ describe('TagsMenu component', () => {
     await act(async () => {
       wrapper = mount(
         <Router history={historyMock}>
-          <TagsMenu idToken='testUser' />
+          <UserContext.Provider value='testUser'><TagsMenu /></UserContext.Provider>
         </Router>
       )
     })

--- a/src/UserContext.js
+++ b/src/UserContext.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const UserContext = React.createContext('')


### PR DESCRIPTION
Instead of passing around idToken to all components that need to make server requests, use React context so any component can access the idToken.

- UserContext creates the user context with `React.createContext`
- App.js uses the UserContext Provider and does not literally pass the idToken to the Route components
- Every component that needs idToken gets it from the UserContext via `useContext`
  - All their unit tests now need to use the context provider too to pass the idToken.